### PR TITLE
Confliction with other modules utilizing the `customMessageItemViewTemplate`

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -88,10 +88,6 @@ module.exports = function (oAppData) {
 							{
 								oParams.View.customMessageItemViewTemplate('%ModuleName%_MessageItemView');
 							}
-							else
-							{
-								oParams.View.customMessageItemViewTemplate('');
-							}
 						});
 					}
 				});


### PR DESCRIPTION
This was causing a confliction when using the `customMessageItemViewTemplate` method in any other module.
The line removed sets the `customMessageItemViewTemplate` to nothing, meaning anything that was set before this module was loaded will be overwritten.